### PR TITLE
feat: consistent parameter validation across all services

### DIFF
--- a/assessments.go
+++ b/assessments.go
@@ -16,6 +16,10 @@ type AssessmentsService struct {
 
 // Get retrieves an assessment by ID.
 func (s *AssessmentsService) Get(ctx context.Context, id string) (*Assessment, error) {
+	if id == "" {
+		return nil, &Error{Code: "ERR_INVALID_PARAM", Message: "assessment id is required"}
+	}
+
 	auth, err := s.client.orgAuthEditor()
 	if err != nil {
 		return nil, err
@@ -46,6 +50,10 @@ type CreateAssessmentRequest struct {
 
 // Create requests a new assessment for an asset.
 func (s *AssessmentsService) Create(ctx context.Context, assetID string, req *CreateAssessmentRequest) (*Assessment, error) {
+	if assetID == "" {
+		return nil, &Error{Code: "ERR_INVALID_PARAM", Message: "asset id is required"}
+	}
+
 	if req == nil {
 		return nil, &Error{Code: "ERR_INVALID_REQUEST", Message: "CreateAssessmentRequest cannot be nil"}
 	}
@@ -78,6 +86,10 @@ func (s *AssessmentsService) Create(ctx context.Context, assetID string, req *Cr
 
 // ListByAsset returns a page of assessments for an asset.
 func (s *AssessmentsService) ListByAsset(ctx context.Context, assetID string, opts *ListOptions) (*Page[AssessmentListItem], error) {
+	if assetID == "" {
+		return nil, &Error{Code: "ERR_INVALID_PARAM", Message: "asset id is required"}
+	}
+
 	auth, err := s.client.orgAuthEditor()
 	if err != nil {
 		return nil, err
@@ -127,6 +139,10 @@ func (s *AssessmentsService) AllByAsset(ctx context.Context, assetID string, opt
 
 // Cancel cancels a running assessment.
 func (s *AssessmentsService) Cancel(ctx context.Context, id string) (*Assessment, error) {
+	if id == "" {
+		return nil, &Error{Code: "ERR_INVALID_PARAM", Message: "assessment id is required"}
+	}
+
 	auth, err := s.client.orgAuthEditor()
 	if err != nil {
 		return nil, err
@@ -151,6 +167,10 @@ func (s *AssessmentsService) Cancel(ctx context.Context, id string) (*Assessment
 
 // Pause pauses a running assessment.
 func (s *AssessmentsService) Pause(ctx context.Context, id string) (*Assessment, error) {
+	if id == "" {
+		return nil, &Error{Code: "ERR_INVALID_PARAM", Message: "assessment id is required"}
+	}
+
 	auth, err := s.client.orgAuthEditor()
 	if err != nil {
 		return nil, err
@@ -175,6 +195,10 @@ func (s *AssessmentsService) Pause(ctx context.Context, id string) (*Assessment,
 
 // Resume resumes a paused assessment.
 func (s *AssessmentsService) Resume(ctx context.Context, id string) (*Assessment, error) {
+	if id == "" {
+		return nil, &Error{Code: "ERR_INVALID_PARAM", Message: "assessment id is required"}
+	}
+
 	auth, err := s.client.orgAuthEditor()
 	if err != nil {
 		return nil, err

--- a/assessments_test.go
+++ b/assessments_test.go
@@ -250,6 +250,46 @@ type fakeItem struct {
 	oneOf *fakeOneOf
 }
 
+func TestAssessmentsServiceEmptyID(t *testing.T) {
+	client, _ := NewClient(WithOrganizationKey("test-key"))
+	ctx := context.TODO()
+
+	tests := []struct {
+		name string
+		fn   func() error
+		msg  string
+	}{
+		{"Get", func() error { _, err := client.Assessments.Get(ctx, ""); return err }, "assessment id is required"},
+		{"Create", func() error {
+			_, err := client.Assessments.Create(ctx, "", &CreateAssessmentRequest{AttackCredits: 100})
+			return err
+		}, "asset id is required"},
+		{"ListByAsset", func() error { _, err := client.Assessments.ListByAsset(ctx, "", nil); return err }, "asset id is required"},
+		{"Cancel", func() error { _, err := client.Assessments.Cancel(ctx, ""); return err }, "assessment id is required"},
+		{"Pause", func() error { _, err := client.Assessments.Pause(ctx, ""); return err }, "assessment id is required"},
+		{"Resume", func() error { _, err := client.Assessments.Resume(ctx, ""); return err }, "assessment id is required"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fn()
+			if err == nil {
+				t.Fatal("expected error for empty id")
+			}
+			var apiErr *Error
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("expected *Error, got %T", err)
+			}
+			if apiErr.Code != "ERR_INVALID_PARAM" {
+				t.Errorf("Code = %q, want 'ERR_INVALID_PARAM'", apiErr.Code)
+			}
+			if apiErr.Message != tt.msg {
+				t.Errorf("Message = %q, want %q", apiErr.Message, tt.msg)
+			}
+		})
+	}
+}
+
 func TestConvertRecentEvents(t *testing.T) {
 	now := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
 	getOneOf := func(item fakeItem) rawUnion {

--- a/assets.go
+++ b/assets.go
@@ -43,6 +43,10 @@ type AssetsService struct {
 
 // Get retrieves an asset by ID.
 func (s *AssetsService) Get(ctx context.Context, id string) (*Asset, error) {
+	if id == "" {
+		return nil, &Error{Code: "ERR_INVALID_PARAM", Message: "asset id is required"}
+	}
+
 	auth, err := s.client.orgAuthEditor()
 	if err != nil {
 		return nil, err
@@ -80,6 +84,10 @@ type UpdateAssetRequest struct {
 
 // Update updates an asset.
 func (s *AssetsService) Update(ctx context.Context, id string, req *UpdateAssetRequest) (*Asset, error) {
+	if id == "" {
+		return nil, &Error{Code: "ERR_INVALID_PARAM", Message: "asset id is required"}
+	}
+
 	if req == nil {
 		return nil, &Error{Code: "ERR_INVALID_REQUEST", Message: "UpdateAssetRequest cannot be nil"}
 	}
@@ -125,6 +133,10 @@ type CreateAssetRequest struct {
 
 // Create creates a new asset in an organization.
 func (s *AssetsService) Create(ctx context.Context, organizationID string, req *CreateAssetRequest) (*Asset, error) {
+	if organizationID == "" {
+		return nil, &Error{Code: "ERR_INVALID_PARAM", Message: "organization id is required"}
+	}
+
 	if req == nil {
 		return nil, &Error{Code: "ERR_INVALID_REQUEST", Message: "CreateAssetRequest cannot be nil"}
 	}
@@ -157,6 +169,10 @@ func (s *AssetsService) Create(ctx context.Context, organizationID string, req *
 
 // ListByOrganization returns a page of assets for an organization.
 func (s *AssetsService) ListByOrganization(ctx context.Context, organizationID string, opts *ListOptions) (*Page[AssetListItem], error) {
+	if organizationID == "" {
+		return nil, &Error{Code: "ERR_INVALID_PARAM", Message: "organization id is required"}
+	}
+
 	auth, err := s.client.orgAuthEditor()
 	if err != nil {
 		return nil, err

--- a/assets_test.go
+++ b/assets_test.go
@@ -745,6 +745,41 @@ func TestCreateAssetNilRequest(t *testing.T) {
 	}
 }
 
+func TestAssetsServiceEmptyID(t *testing.T) {
+	client, _ := NewClient(WithOrganizationKey("test-key"))
+	ctx := context.TODO()
+
+	tests := []struct {
+		name string
+		fn   func() error
+		msg  string
+	}{
+		{"Get", func() error { _, err := client.Assets.Get(ctx, ""); return err }, "asset id is required"},
+		{"Update", func() error { _, err := client.Assets.Update(ctx, "", &UpdateAssetRequest{}); return err }, "asset id is required"},
+		{"Create", func() error { _, err := client.Assets.Create(ctx, "", &CreateAssetRequest{Name: "test"}); return err }, "organization id is required"},
+		{"ListByOrganization", func() error { _, err := client.Assets.ListByOrganization(ctx, "", nil); return err }, "organization id is required"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fn()
+			if err == nil {
+				t.Fatal("expected error for empty id")
+			}
+			var apiErr *Error
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("expected *Error, got %T", err)
+			}
+			if apiErr.Code != "ERR_INVALID_PARAM" {
+				t.Errorf("Code = %q, want 'ERR_INVALID_PARAM'", apiErr.Code)
+			}
+			if apiErr.Message != tt.msg {
+				t.Errorf("Message = %q, want %q", apiErr.Message, tt.msg)
+			}
+		})
+	}
+}
+
 func TestConvertCheckError(t *testing.T) {
 	t.Run("returns nil for nil input", func(t *testing.T) {
 		got := convertCheckError(nil)

--- a/findings.go
+++ b/findings.go
@@ -14,6 +14,10 @@ type FindingsService struct {
 
 // Get retrieves a finding by ID.
 func (s *FindingsService) Get(ctx context.Context, id string) (*Finding, error) {
+	if id == "" {
+		return nil, &Error{Code: "ERR_INVALID_PARAM", Message: "finding id is required"}
+	}
+
 	auth, err := s.client.orgAuthEditor()
 	if err != nil {
 		return nil, err
@@ -38,6 +42,10 @@ func (s *FindingsService) Get(ctx context.Context, id string) (*Finding, error) 
 
 // ListByAsset returns a page of findings for an asset.
 func (s *FindingsService) ListByAsset(ctx context.Context, assetID string, opts *ListOptions) (*Page[FindingListItem], error) {
+	if assetID == "" {
+		return nil, &Error{Code: "ERR_INVALID_PARAM", Message: "asset id is required"}
+	}
+
 	auth, err := s.client.orgAuthEditor()
 	if err != nil {
 		return nil, err
@@ -89,6 +97,10 @@ func (s *FindingsService) AllByAsset(ctx context.Context, assetID string, opts *
 // This triggers a targeted assessment to verify the vulnerability has been mitigated.
 // Returns the assessment created for the verification.
 func (s *FindingsService) VerifyFix(ctx context.Context, id string) (*Assessment, error) {
+	if id == "" {
+		return nil, &Error{Code: "ERR_INVALID_PARAM", Message: "finding id is required"}
+	}
+
 	auth, err := s.client.orgAuthEditor()
 	if err != nil {
 		return nil, err

--- a/findings_test.go
+++ b/findings_test.go
@@ -1,6 +1,8 @@
 package xbow
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -251,6 +253,40 @@ func TestFindingListItemFields(t *testing.T) {
 	}
 	if !item.UpdatedAt.Equal(now.Add(time.Hour)) {
 		t.Errorf("UpdatedAt = %v, want %v", item.UpdatedAt, now.Add(time.Hour))
+	}
+}
+
+func TestFindingsServiceEmptyID(t *testing.T) {
+	client, _ := NewClient(WithOrganizationKey("test-key"))
+	ctx := context.TODO()
+
+	tests := []struct {
+		name string
+		fn   func() error
+		msg  string
+	}{
+		{"Get", func() error { _, err := client.Findings.Get(ctx, ""); return err }, "finding id is required"},
+		{"ListByAsset", func() error { _, err := client.Findings.ListByAsset(ctx, "", nil); return err }, "asset id is required"},
+		{"VerifyFix", func() error { _, err := client.Findings.VerifyFix(ctx, ""); return err }, "finding id is required"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fn()
+			if err == nil {
+				t.Fatal("expected error for empty id")
+			}
+			var apiErr *Error
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("expected *Error, got %T", err)
+			}
+			if apiErr.Code != "ERR_INVALID_PARAM" {
+				t.Errorf("Code = %q, want 'ERR_INVALID_PARAM'", apiErr.Code)
+			}
+			if apiErr.Message != tt.msg {
+				t.Errorf("Message = %q, want %q", apiErr.Message, tt.msg)
+			}
+		})
 	}
 }
 

--- a/organizations.go
+++ b/organizations.go
@@ -16,6 +16,10 @@ type OrganizationsService struct {
 // Get retrieves an organization by ID.
 // This endpoint accepts either an organization key or an integration key.
 func (s *OrganizationsService) Get(ctx context.Context, id string) (*Organization, error) {
+	if id == "" {
+		return nil, &Error{Code: "ERR_INVALID_PARAM", Message: "organization id is required"}
+	}
+
 	auth, err := s.client.orgOrIntegrationAuthEditor()
 	if err != nil {
 		return nil, err
@@ -48,6 +52,10 @@ type UpdateOrganizationRequest struct {
 // Update updates an organization.
 // This endpoint requires an integration key.
 func (s *OrganizationsService) Update(ctx context.Context, id string, req *UpdateOrganizationRequest) (*Organization, error) {
+	if id == "" {
+		return nil, &Error{Code: "ERR_INVALID_PARAM", Message: "organization id is required"}
+	}
+
 	if req == nil {
 		return nil, &Error{Code: "ERR_INVALID_REQUEST", Message: "UpdateOrganizationRequest cannot be nil"}
 	}
@@ -94,6 +102,10 @@ type CreateOrganizationRequest struct {
 // Create creates a new organization in an integration.
 // This endpoint requires an integration key.
 func (s *OrganizationsService) Create(ctx context.Context, integrationID string, req *CreateOrganizationRequest) (*Organization, error) {
+	if integrationID == "" {
+		return nil, &Error{Code: "ERR_INVALID_PARAM", Message: "integration id is required"}
+	}
+
 	if req == nil {
 		return nil, &Error{Code: "ERR_INVALID_REQUEST", Message: "CreateOrganizationRequest cannot be nil"}
 	}
@@ -145,6 +157,10 @@ func (s *OrganizationsService) Create(ctx context.Context, integrationID string,
 // ListByIntegration returns a page of organizations for an integration.
 // This endpoint requires an integration key.
 func (s *OrganizationsService) ListByIntegration(ctx context.Context, integrationID string, opts *ListOptions) (*Page[OrganizationListItem], error) {
+	if integrationID == "" {
+		return nil, &Error{Code: "ERR_INVALID_PARAM", Message: "integration id is required"}
+	}
+
 	auth, err := s.client.integrationAuthEditor()
 	if err != nil {
 		return nil, err
@@ -193,6 +209,10 @@ type CreateKeyRequest struct {
 // CreateKey creates a new API key for an organization.
 // This endpoint requires an integration key.
 func (s *OrganizationsService) CreateKey(ctx context.Context, organizationID string, req *CreateKeyRequest) (*OrganizationAPIKey, error) {
+	if organizationID == "" {
+		return nil, &Error{Code: "ERR_INVALID_PARAM", Message: "organization id is required"}
+	}
+
 	if req == nil {
 		return nil, &Error{Code: "ERR_INVALID_REQUEST", Message: "CreateKeyRequest cannot be nil"}
 	}
@@ -226,6 +246,10 @@ func (s *OrganizationsService) CreateKey(ctx context.Context, organizationID str
 // RevokeKey revokes an organization API key.
 // This endpoint requires an integration key.
 func (s *OrganizationsService) RevokeKey(ctx context.Context, keyID string) error {
+	if keyID == "" {
+		return &Error{Code: "ERR_INVALID_PARAM", Message: "key id is required"}
+	}
+
 	auth, err := s.client.integrationAuthEditor()
 	if err != nil {
 		return err

--- a/organizations_test.go
+++ b/organizations_test.go
@@ -335,6 +335,52 @@ func TestCreateKeyNilRequest(t *testing.T) {
 	}
 }
 
+func TestOrganizationsServiceEmptyID(t *testing.T) {
+	client, _ := NewClient(WithOrganizationKey("test-key"))
+	ctx := context.TODO()
+
+	tests := []struct {
+		name string
+		fn   func() error
+		msg  string
+	}{
+		{"Get", func() error { _, err := client.Organizations.Get(ctx, ""); return err }, "organization id is required"},
+		{"Update", func() error {
+			_, err := client.Organizations.Update(ctx, "", &UpdateOrganizationRequest{Name: "test"})
+			return err
+		}, "organization id is required"},
+		{"Create", func() error {
+			_, err := client.Organizations.Create(ctx, "", &CreateOrganizationRequest{Name: "test", Members: []OrganizationMember{{Email: "a@b.com", Name: "a"}}})
+			return err
+		}, "integration id is required"},
+		{"ListByIntegration", func() error { _, err := client.Organizations.ListByIntegration(ctx, "", nil); return err }, "integration id is required"},
+		{"CreateKey", func() error {
+			_, err := client.Organizations.CreateKey(ctx, "", &CreateKeyRequest{Name: "test"})
+			return err
+		}, "organization id is required"},
+		{"RevokeKey", func() error { return client.Organizations.RevokeKey(ctx, "") }, "key id is required"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fn()
+			if err == nil {
+				t.Fatal("expected error for empty id")
+			}
+			var apiErr *Error
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("expected *Error, got %T", err)
+			}
+			if apiErr.Code != "ERR_INVALID_PARAM" {
+				t.Errorf("Code = %q, want 'ERR_INVALID_PARAM'", apiErr.Code)
+			}
+			if apiErr.Message != tt.msg {
+				t.Errorf("Message = %q, want %q", apiErr.Message, tt.msg)
+			}
+		})
+	}
+}
+
 func TestOrganizationStateConstants(t *testing.T) {
 	tests := []struct {
 		state OrganizationState

--- a/reports.go
+++ b/reports.go
@@ -17,6 +17,10 @@ type ReportsService struct {
 // Get downloads a report as PDF bytes by ID.
 // The returned bytes are the raw PDF file content.
 func (s *ReportsService) Get(ctx context.Context, id string) ([]byte, error) {
+	if id == "" {
+		return nil, &Error{Code: "ERR_INVALID_PARAM", Message: "report id is required"}
+	}
+
 	auth, err := s.client.orgAuthEditor()
 	if err != nil {
 		return nil, err
@@ -33,6 +37,10 @@ func (s *ReportsService) Get(ctx context.Context, id string) ([]byte, error) {
 
 // GetSummary retrieves the markdown summary of a report by ID.
 func (s *ReportsService) GetSummary(ctx context.Context, id string) (*ReportSummary, error) {
+	if id == "" {
+		return nil, &Error{Code: "ERR_INVALID_PARAM", Message: "report id is required"}
+	}
+
 	auth, err := s.client.orgAuthEditor()
 	if err != nil {
 		return nil, err
@@ -57,6 +65,10 @@ func (s *ReportsService) GetSummary(ctx context.Context, id string) (*ReportSumm
 
 // ListByAsset returns a page of reports for an asset.
 func (s *ReportsService) ListByAsset(ctx context.Context, assetID string, opts *ListOptions) (*Page[ReportListItem], error) {
+	if assetID == "" {
+		return nil, &Error{Code: "ERR_INVALID_PARAM", Message: "asset id is required"}
+	}
+
 	auth, err := s.client.orgAuthEditor()
 	if err != nil {
 		return nil, err

--- a/reports_test.go
+++ b/reports_test.go
@@ -1,6 +1,8 @@
 package xbow
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -127,6 +129,40 @@ func TestReportListItemFields(t *testing.T) {
 	}
 	if !item.CreatedAt.Equal(now) {
 		t.Errorf("CreatedAt = %v, want %v", item.CreatedAt, now)
+	}
+}
+
+func TestReportsServiceEmptyID(t *testing.T) {
+	client, _ := NewClient(WithOrganizationKey("test-key"))
+	ctx := context.TODO()
+
+	tests := []struct {
+		name string
+		fn   func() error
+		msg  string
+	}{
+		{"Get", func() error { _, err := client.Reports.Get(ctx, ""); return err }, "report id is required"},
+		{"GetSummary", func() error { _, err := client.Reports.GetSummary(ctx, ""); return err }, "report id is required"},
+		{"ListByAsset", func() error { _, err := client.Reports.ListByAsset(ctx, "", nil); return err }, "asset id is required"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fn()
+			if err == nil {
+				t.Fatal("expected error for empty id")
+			}
+			var apiErr *Error
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("expected *Error, got %T", err)
+			}
+			if apiErr.Code != "ERR_INVALID_PARAM" {
+				t.Errorf("Code = %q, want 'ERR_INVALID_PARAM'", apiErr.Code)
+			}
+			if apiErr.Message != tt.msg {
+				t.Errorf("Message = %q, want %q", apiErr.Message, tt.msg)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Validates all required path parameters for empty string at the top of each service method, returning `*Error` with code `ERR_INVALID_PARAM`. This matches the existing pattern in `WebhooksService` and prevents confusing 404 errors from the API when empty IDs are passed.

## Changes

**Services updated:** Assessments, Assets, Findings, Organizations, Reports

- 22 validation checks added across 5 services
- Table-driven tests for every validated method
- Uses Option A (`&Error{Code: "ERR_INVALID_PARAM", ...}`) for consistency with existing webhooks code

Closes #37