### PR TITLE
feat: return io.ReadCloser from Reports.Get for streaming downloads

### DIFF
--- a/client.go
+++ b/client.go
@@ -277,3 +277,36 @@ func (c *Client) do(ctx context.Context, method, path string, auth runtime.Reque
 
 	return body, nil
 }
+
+// doStream executes a raw HTTP request and returns the response body as a streaming reader.
+// The caller is responsible for closing the returned ReadCloser.
+// Non-2xx responses are returned as a structured *Error with StatusCode set.
+func (c *Client) doStream(ctx context.Context, method, path string, auth runtime.RequestEditorFn) (io.ReadCloser, error) {
+	url := c.baseURL + path
+
+	req, err := http.NewRequestWithContext(ctx, method, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	if err := auth(ctx, req); err != nil {
+		return nil, fmt.Errorf("applying auth: %w", err)
+	}
+	req.Header.Set("X-XBOW-API-Version", APIVersion)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		defer func() { _ = resp.Body.Close() }()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("reading error response: %w", err)
+		}
+		return nil, wrapRawError(resp.StatusCode, body)
+	}
+
+	return resp.Body, nil
+}

--- a/cmd/xbow/cmd/report.go
+++ b/cmd/xbow/cmd/report.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"iter"
 	"os"
 	"path/filepath"
@@ -38,19 +39,23 @@ var reportGetCmd = &cobra.Command{
 			return err
 		}
 
-		data, err := client.Reports.Get(context.Background(), args[0])
+		rc, err := client.Reports.Get(context.Background(), args[0])
 		if err != nil {
 			return err
 		}
+		defer rc.Close()
 
+		var w io.Writer = os.Stdout
 		if reportGetOutputFile != "" {
-			if err := os.WriteFile(filepath.Clean(reportGetOutputFile), data, 0o644); err != nil { //nolint:gosec // PDF output file; 0644 is intentional
-				return fmt.Errorf("writing file: %w", err)
+			f, err := os.Create(filepath.Clean(reportGetOutputFile))
+			if err != nil {
+				return fmt.Errorf("creating file: %w", err)
 			}
-			return nil
+			defer func() { _ = f.Close() }()
+			w = f
 		}
 
-		_, err = os.Stdout.Write(data)
+		_, err = io.Copy(w, rc)
 		return err
 	},
 }

--- a/reports.go
+++ b/reports.go
@@ -3,6 +3,7 @@ package xbow
 import (
 	"context"
 	"fmt"
+	"io"
 	"iter"
 	"net/http"
 
@@ -14,9 +15,22 @@ type ReportsService struct {
 	client *Client
 }
 
-// Get downloads a report as PDF bytes by ID.
-// The returned bytes are the raw PDF file content.
-func (s *ReportsService) Get(ctx context.Context, id string) ([]byte, error) {
+// Get returns the report PDF as a streaming reader.
+// The caller is responsible for closing the returned ReadCloser.
+//
+// Example:
+//
+//	rc, err := client.Reports.Get(ctx, "report-id")
+//	if err != nil {
+//	    return err
+//	}
+//	defer rc.Close()
+//
+//	// Write to file
+//	f, _ := os.Create("report.pdf")
+//	defer f.Close()
+//	io.Copy(f, rc)
+func (s *ReportsService) Get(ctx context.Context, id string) (io.ReadCloser, error) {
 	if id == "" {
 		return nil, &Error{Code: "ERR_INVALID_PARAM", Message: "report id is required"}
 	}
@@ -27,12 +41,7 @@ func (s *ReportsService) Get(ctx context.Context, id string) ([]byte, error) {
 	}
 
 	path := fmt.Sprintf("/api/v1/reports/%s", id)
-	body, err := s.client.do(ctx, http.MethodGet, path, auth)
-	if err != nil {
-		return nil, err
-	}
-
-	return body, nil
+	return s.client.doStream(ctx, http.MethodGet, path, auth)
 }
 
 // GetSummary retrieves the markdown summary of a report by ID.


### PR DESCRIPTION
## Summary

`Reports.Get` previously buffered the entire PDF into memory via `io.ReadAll`. This changes it to return an `io.ReadCloser`, letting callers stream directly to files or downstream writers without holding large reports in memory.

This is a simpler alternative to the three-method approach proposed in #38 — a single `Get` returning `io.ReadCloser` follows standard Go patterns (`http.Response.Body`, `os.Open`) and callers can trivially `io.ReadAll` or `io.Copy` as needed.

## Changes

- Add `doStream` method on `Client` that returns `io.ReadCloser` instead of `[]byte`, closing the body only on error responses
- Change `Reports.Get` signature from `([]byte, error)` to `(io.ReadCloser, error)`
- Update CLI `report get` command to stream via `io.Copy` instead of buffering with `os.WriteFile`

Closes #38